### PR TITLE
Many-to-many relationships

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -8,6 +8,7 @@ import { App } from "./src/ui/app";
 import { generateKeyBetween } from "fractional-indexing";
 import { useAppState } from "./src/global";
 import { Editor } from "./src/editor";
+import { ElementRelations } from "./src/elementRelations";
 
 async function init() {
   const client = createClient({
@@ -33,14 +34,14 @@ async function init() {
           parentIndex: generateKeyBetween(null, null),
         } satisfies FileFormat.Level)],
       ]),
+      elementRelations: new LiveMap(),
     }
   });
   const { root } = await room.getStorage();
 
   console.log(`Entered.`);
 
-  const store = new ProjectStore(room, root as any);
-  const editor = new Editor(store);
+  const editor = new Editor(room, root as any);
 
   const onFrame = () => {
     editor.onFrame();

--- a/src/changeManager.ts
+++ b/src/changeManager.ts
@@ -1,0 +1,34 @@
+import { Room } from "@liveblocks/client";
+
+/**
+ * Any local mutation to objects in any store must be wrapped in a `makeChanges()` call. This
+ * ensures batching, but also allows us to distinguish between local and remote changes.
+ */
+export class ChangeManager {
+  private makeChangesRefCount = 0;
+
+  constructor(
+    private room: Room,
+  ) {}
+
+  public makingChanges(): boolean {
+    return this.makeChangesRefCount > 0;
+  }
+
+  public makeChanges<T>(cb: () => T): T {
+    this.makeChangesRefCount++;
+    if (this.makeChangesRefCount > 1) {
+      return cb();
+    }
+
+    const ret = this.room.batch(() => {
+      return cb();
+    })
+
+    // Don't let changes accumulate in LiveBlock's history -- we're managing our own undo/redo.
+    this.room.history.clear();
+
+    this.makeChangesRefCount--;
+    return ret;
+  }
+}

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,61 +1,31 @@
-import { ChangeOrigin, ObjectChange } from "./arcolObjectStore";
-import { ElementObserver, ProjectStore } from "./project";
+import { ProjectStore } from "./project";
 import { UndoHistory } from "./undoRedo";
-import { Element } from "./elements/element";
-import { HierarchyObserver } from "./hierarchyMixin";
-import { ElementId } from "./fileFormat";
-
-class DeleteEmptyExtrusionObserver implements ElementObserver {
-  private elementsToCheck = new Set<ElementId>();
-
-  constructor(private editor: Editor) {}
-
-  public onChange(obj: Element, _origin: ChangeOrigin, change: ObjectChange) {
-    if (obj.type === "sketch") {
-      if (obj.parent?.type === "extrusion" && change.type === "delete") {
-        this.elementsToCheck.add(obj.parent.id);
-      }
-      if (change.type === "update" && change.property === "parentId") {
-        const oldParent = this.editor.store.getById(change.oldValue);
-        if (oldParent?.type === "extrusion") {
-          this.elementsToCheck.add(oldParent.id);
-        }
-      }
-    }
-  }
-
-  public runDeferredWork() {
-    for (const id of this.elementsToCheck) {
-      const element = this.editor.store.getById(id);
-      if (element?.type === "extrusion" && element.children.length === 0) {
-        this.editor.store.removeObject(element)
-      }
-    }
-    this.elementsToCheck.clear();
-  }
-}
+import { ElementRelations } from "./elementRelations";
+import { LiveObject, Room } from "@liveblocks/client";
+import { FileFormat } from "./fileFormat";
+import { ChangeManager } from "./changeManager";
 
 export class Editor {
-  public readonly store: ProjectStore;
   public readonly undoTracker: UndoHistory;
+  public readonly changeManager: ChangeManager;
+  public readonly project: ProjectStore;
+  public readonly relations: ElementRelations;
 
-  private observers: ElementObserver[];
-
-  constructor(store: ProjectStore) {
-    this.store = store;
+  constructor(
+    room: Room,
+    liveblocksRoot: LiveObject<FileFormat.Project>,
+  ) {
     this.undoTracker = new UndoHistory(this);
+    this.changeManager = new ChangeManager(room);
 
-    this.observers = [
-      new HierarchyObserver(this.store),
-      { onChange: (obj, origin, change) => this.undoTracker.onChange(this.store, obj, origin, change) },
-      new DeleteEmptyExtrusionObserver(this),
-    ];
+    this.relations = new ElementRelations(room, liveblocksRoot, this.changeManager,
+      { onChange: (obj, origin, change) => this.undoTracker.onChange(this.relations, obj, origin, change) },
+    );
 
-    this.store.subscribeObjectChange((obj, origin, change) => {
-      for (const observer of this.observers) {
-        observer.onChange(obj, origin, change);
-      }
-    });
+    this.project = new ProjectStore(room, liveblocksRoot, this.changeManager,
+      [this.relations.observerA, this.relations.observerB],
+      { onChange: (obj, origin, change) => this.undoTracker.onChange(this.project, obj, origin, change) },
+    );
   }
 
   public onFrame() {
@@ -63,15 +33,15 @@ export class Editor {
     // If it's a problem that the changes cannot be undone, the nature of that asynchronous change
     // should be revisited.
     this.undoTracker.ignoreUndoRedoScope(() => {
-      this.runDeferredWork();
+      this.project.runDeferredWork();
     });
   }
 
   public runDeferredWork() {
-    this.store.makeChanges(() => {
-      for (const observer of this.observers) {
-        observer.runDeferredWork?.();
-      }
-    });
+    this.project.runDeferredWork();
+  }
+
+  public makeChanges<T>(cb: () => T): T {
+    return this.changeManager.makeChanges(cb);
   }
 }

--- a/src/elementRelations.ts
+++ b/src/elementRelations.ts
@@ -1,0 +1,49 @@
+import { LiveObject, Room } from "@liveblocks/client";
+import { ElementId, FileFormat } from "./fileFormat";
+import { Relation, RelationsStore } from "./relationsStore";
+import { Element } from "./elements/element";
+import { ObjectObserver, StoreName } from "./arcolObjectStore";
+import { ChangeManager } from "./changeManager";
+
+export class ElementRelation extends Relation<ElementId, ElementId, ElementRelation> {
+}
+
+export class ElementRelations extends RelationsStore<ElementId, ElementId, ElementRelation> {
+  constructor(
+    room: Room,
+    liveblocksRoot: LiveObject<FileFormat.Project>,
+    changeManager: ChangeManager,
+    undoTrackerObserver: ObjectObserver<ElementRelation>,
+  ) {
+    super(room, liveblocksRoot.get("elementRelations"), changeManager);
+
+    this.initialize();
+
+    this.subscribeObjectChange((obj, origin, change) => {
+      undoTrackerObserver.onChange(obj, origin, change);
+    });
+  }
+
+  get name() {
+    return "element-relations" as StoreName;
+  }
+
+  public addElementRelation(elementA: Element, elementB: Element) {
+    const key = `${elementA.id}<>${elementB.id}`;
+    const node = new LiveObject({ id: key });
+    const relation = new ElementRelation(this, node);
+    this.addObject(relation);
+    return relation;
+  }
+
+  public removeElementRelation(a: ElementId, b: ElementId) {
+    const relation = this.objects.get(`${a}<>${b}`);
+    if (relation) {
+      this.removeObject(relation);
+    }
+  }
+
+  public objectFromLiveObject(node: LiveObject<any>): ElementRelation {
+    return new ElementRelation(this, node);
+  }
+}

--- a/src/fileFormat.ts
+++ b/src/fileFormat.ts
@@ -12,6 +12,7 @@ export type Brand<T, BrandString extends string> = T & {
 };
 
 export type ElementId = Brand<string, "element-id">;
+export type ElementRelationKey = Brand<string, "element-element-relation">;
 
 /**
  * Just a simple example of a file format.
@@ -19,17 +20,8 @@ export type ElementId = Brand<string, "element-id">;
 export namespace FileFormat {
   export type Vec3 = [number, number, number];
 
-  /**
-   * Note that this is making the `parent` relationship a first-class property of all objects.
-   * Furthermore, all children as sorted, even in use cases where it probably doesn't matter too
-   * much.
-   *
-   * I think the extra overhead of maintaining this relationship is worth it for the simplicity
-   * of making all objects consistent, and for future proofing.
-   */
   export type ObjectShared<I> = {
     id: I;
-    type: string;
   }
 
   export type HierarchyMixin<I> = {
@@ -60,8 +52,13 @@ export namespace FileFormat {
 
   export type Element = Sketch | Extrusion | Group | Level;
 
+  export type ElementRelation = {
+    id: ElementRelationKey;
+  }
+
   export type Project = {
     name: ElementId;
     elements: LiveMap<ElementId, LiveObject<Element>>;
+    elementRelations: LiveMap<ElementRelationKey, LiveObject<ElementRelation>>;
   }
 }

--- a/src/relationsStore.ts
+++ b/src/relationsStore.ts
@@ -1,0 +1,151 @@
+import { LiveObject } from "@liveblocks/client";
+import { ArcolObject, ArcolObjectStore, ChangeOrigin, ObjectChange, ObjectObserver } from "./arcolObjectStore";
+import { FileFormat } from "./fileFormat";
+
+/**
+ * A relation represents a one-way connection from two objects A -> B. The id is expected to take
+ * the form `guid<>guid` so that relations can be unique.
+ *
+ * Relations can have attached data, but you can't change the object IDs being connected without
+ * creating a new relation.
+ */
+export class Relation<
+  IA extends string,
+  IB extends string,
+  O extends Relation<IA, IB, O>
+> extends ArcolObject<`${IA}<>${IB}`, O> {
+  public readonly keyA: IA;
+  public readonly keyB: IB;
+
+  constructor(
+    store: RelationsStore<IA, IB, O>,
+    node: LiveObject<FileFormat.ObjectShared<string>>
+  ) {
+    super(store, node, {});
+    const parts = this.id.split("<>");
+    if (parts.length !== 2) {
+      throw new Error("Invalid relation id");
+    }
+    this.keyA = parts[0] as IA;
+    this.keyB = parts[1] as IB;
+  }
+}
+
+/**
+ * A relations store is a special type of store meant to represent a many-to-many relationship
+ * between objects of two different (or the same) store.
+ *
+ * By listening to changes in the base object stores, we maintain an "index" of relations, as well
+ * clean up invalid relations whether due to the deletion of an object locally or remotely.
+ *
+ * Note that this kind of client-side approach doesn't 100% guarantee that invalid relations no
+ * longer exist: the clients could disconnect before it has the chance to send out the deletion
+ * of a relation.
+ */
+export abstract class RelationsStore<
+  IA extends string,
+  IB extends string,
+  O extends Relation<IA, IB, O>,
+> extends ArcolObjectStore<`${IA}<>${IB}`, O> {
+  private relationsFromA = new Map<IA, Set<O>>();
+  private relationsFromB = new Map<IB, Set<O>>();
+
+  // The owner of this class should put these observers in the respective stores whose objects
+  // are being related.
+  public readonly observerA: ObjectObserver<ArcolObject<IA, any>> =
+    { onChange: this.onObjectChangeA.bind(this) };
+  public readonly observerB: ObjectObserver<ArcolObject<IB, any>> =
+    { onChange: this.onObjectChangeB.bind(this) };
+
+  protected initialize() {
+    super.initialize();
+
+    for (const obj of this.objects.values()) {
+      this.addRelation(obj);
+    }
+
+    // Update the internal indices when relations are added or removed. The listener should take
+    // "precedence" over regular product listeners because it's important to update the store's
+    // internal data structures before the product listeners are called.
+    //
+    // An alternative implementation could be to have abstract methods on `ArcolObjectStore` that
+    // we override in this subclass, to _really_ ensure that we handle object changes here first
+    // before other listeners.
+    this.subscribeObjectChange((obj, origin, change) => {
+      if (change.type === "create") {
+        this.addRelation(obj);
+      } else if (change.type === "delete") {
+        this.removeRelation(obj);
+      }
+    });
+  }
+
+  public getRelationsFromA(key: IA): Set<O> {
+    return this.relationsFromA.get(key) || new Set();
+  }
+
+  public getRelationsFromB(key: IA): Set<O> {
+    return this.relationsFromA.get(key) || new Set();
+  }
+
+  public getRelation(a: IA, b: IB): O | undefined {
+    return this.objects.get(`${a}<>${b}`) as O | undefined;
+  }
+
+  public hasRelation(a: IA, b: IB): boolean {
+    return !!this.getRelation(a, b);
+  }
+
+  private removeRelation(relation: O) {
+    this.relationsFromA.get(relation.keyA)?.delete(relation);
+    this.relationsFromB.get(relation.keyB)?.delete(relation);
+  }
+
+  private addRelation(relation: O) {
+    let relationsA = this.relationsFromA.get(relation.keyA);
+    if (!relationsA) {
+      relationsA = new Set();
+      this.relationsFromA.set(relation.keyA, relationsA);
+    }
+    relationsA.add(relation);
+
+    let relationsB = this.relationsFromB.get(relation.keyB);
+    if (!relationsB) {
+      relationsB = new Set();
+      this.relationsFromB.set(relation.keyB, relationsB);
+    }
+    relationsB.add(relation);
+  }
+
+  /**
+   * Cleans up relations related to an object instance of type A when it is deleted.
+   */
+  private onObjectChangeA(obj: ArcolObject<IA, any>, _origin: ChangeOrigin, change: ObjectChange) {
+    if (change.type === "delete") {
+      const relations = this.relationsFromA.get(obj.id);
+      if (relations) {
+        this.relationsFromA.delete(obj.id);
+        for (const relation of relations) {
+          this.relationsFromB.get(relation.keyB)?.delete(relation);
+          this.removeObject(relation);
+        }
+      }
+    }
+  }
+
+  /**
+   * Cleans up relations related to an object instance of type B when it is deleted.
+   */
+  private onObjectChangeB(obj: ArcolObject<IB, any>, _origin: ChangeOrigin, change: ObjectChange) {
+    if (change.type === "delete") {
+      const relations = this.relationsFromB.get(obj.id);
+      if (relations) {
+        this.relationsFromB.delete(obj.id);
+        for (const relation of relations) {
+          this.relationsFromB.get(relation.keyB)?.delete(relation);
+          this.removeObject(relation);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds an abstraction for creating many-to-many relationships between objects of different stores, by having a "relations" store.

Why store the relations in a separate store instead of on the objects themselves:
- If you store it on the object themselves, it needs to be a nested live object in order to support modifying separate relationships concurrently. I'm avoiding using that feature to keep our usage of the LiveBlocks API simple.
- In any case, you need a listener to remove outdated relationships when the object on which the relationship is not stored is deleted.